### PR TITLE
editorconfig file, to maintain consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.html]
+indent_size = 2
+
+# The JSON files contain newlines inconsistently
+[*.js]
+indent_size = 4
+max_line_length = 119
+
+[*.yml]
+indent_size = 2
+[*.yaml]
+indent_size = 2
+
+[*.{md,txt}]
+trim_trailing_whitespace = true
+indent_style = space
+max_line_length = 80


### PR DESCRIPTION
for what does it do, see: https://editorconfig.org/

tl;dr: a specification respected by almost all formatting tools and code editors to maintain a consistent code formatting no matter which code writing tool you are using

should prevent vscode from mucking up existing code's spacing/formatting


kinda kinda #5 (but doesn't close it entirely)