### PR TITLE
support for query parameter + handle error

### DIFF
--- a/server/src/routes/subjects/subjects.controller.js
+++ b/server/src/routes/subjects/subjects.controller.js
@@ -3,8 +3,14 @@ const { getAllSubjects, updateSubjectState } = require("../../models/subjects.mo
 
 async function httpGetAllSubjects(req, res) {
     const query = req.query;
-    const subjects = await getAllSubjects(convertIntObj(query));
-    return res.send(subjects);
+    try {
+        const subjects = await getAllSubjects(convertIntObj(query));
+        return res.send(subjects);
+    } catch (e) {
+        return res
+            .status(400)
+            .send({ erro: true, error_desc: { query: JSON.stringify(query), msg: e } });
+    }
 }
 
 async function httpUpdateSubjectState(req, res) {

--- a/server/src/routes/subjects/subjects.controller.js
+++ b/server/src/routes/subjects/subjects.controller.js
@@ -7,9 +7,7 @@ async function httpGetAllSubjects(req, res) {
         const subjects = await getAllSubjects(convertIntObj(query));
         return res.send(subjects);
     } catch (e) {
-        return res
-            .status(400)
-            .send({ erro: true, error_desc: { query: JSON.stringify(query), msg: e } });
+        return res.status(400).send({ erro: true, error_desc: { query: JSON.stringify(query), msg: e } });
     }
 }
 

--- a/server/src/routes/teachers/teachers.controller.js
+++ b/server/src/routes/teachers/teachers.controller.js
@@ -8,9 +8,7 @@ async function httpGetAllTeachers(req, res) {
         return res.send(teachers);
     } catch (e) {
         console.error(e);
-        return res
-            .status(400)
-            .send({ error: true, error_desc: { query: JSON.stringify(query), msg: e } });
+        return res.status(400).send({ error: true, error_desc: { query: JSON.stringify(query), msg: e } });
     }
 }
 

--- a/server/src/routes/teachers/teachers.controller.js
+++ b/server/src/routes/teachers/teachers.controller.js
@@ -3,8 +3,15 @@ const { getAllTeachers, addNewTeacher } = require("../../models/teachers.model")
 
 async function httpGetAllTeachers(req, res) {
     const query = req.query;
-    const teachers = await getAllTeachers(convertIntObj(query));
-    return res.send(teachers);
+    try {
+        const teachers = await getAllTeachers(convertIntObj(query));
+        return res.send(teachers);
+    } catch (e) {
+        console.error(e);
+        return res
+            .status(400)
+            .send({ error: true, error_desc: { query: JSON.stringify(query), msg: e } });
+    }
 }
 
 async function httpAddNewTeacher(req, res) {

--- a/server/src/utilities/utils.js
+++ b/server/src/utilities/utils.js
@@ -1,7 +1,9 @@
 function convertIntObj(obj) {
     const res = {};
     for (const key in obj) {
-        if (typeof obj[key] === "object") {
+        if (Array.isArray(obj[key])) {
+            res[key] = obj[key].map(convertIntObj);
+        } else if (typeof obj[key] === "object") {
             res[key] = convertIntObj(obj[key]);
         } else {
             const parsed = parseInt(obj[key]);


### PR DESCRIPTION

## Description
instead of implementing\adding a whole parser to support objects in query params, instead the parser that converts query param strings to int has been modified to support arrays  

also mongodb operators are supported when called from query parameters by default, you just have to be creative with creating objects in arrays using query params syntax 

## Checklist:


- [x] My commits are related to the pull request and look clean.
- [ ] I have made mostly use of tailwind as many places as possible.
- [x] I have added comments on any confusing or complex pieces of code.
- [ ] I have commented the console logs.
- [x] I have tested the changes at my end.
- [x] I have requested for review.
- [ ] I have linked the commits/PR to issue.
